### PR TITLE
Fix 5+ mark support

### DIFF
--- a/desiredMark.json
+++ b/desiredMark.json
@@ -1,3 +1,3 @@
 {
-    "desiredMark": "5"
+    "desiredMark": 5
 }

--- a/lab08/tests/testFilesInFolder.ts
+++ b/lab08/tests/testFilesInFolder.ts
@@ -1,5 +1,5 @@
 import { desiredMark } from '../../desiredMark.json';
-import { DesiredMark } from '../../mark';
+import { DesiredMark, toRank } from '../../mark';
 import { 
     readFileSync, 
     readdirSync  } from 'fs';
@@ -17,7 +17,8 @@ export function addIntGroup(e: any, groups: {[key: string]: string;}, groupName:
 export function testFilesInFolder(folder: string, parseFunc: (source: string)=>any) {
     let files = readdirSync(folder, { withFileTypes: true, recursive: true });
     for (const file of files) {
-        const filePathString = pathJoin(file.parentPath, file.name);
+        const basePath = file.parentPath ?? folder;
+        const filePathString = pathJoin(basePath, file.name);
         const filePath = pathParse(filePathString);
 
         if (!file.isDirectory() && filePath.ext == ".funny") {
@@ -25,7 +26,7 @@ export function testFilesInFolder(folder: string, parseFunc: (source: string)=>a
             const sample = readFileSync(filePathString, 'utf-8');
             const m = filePath.base.match(testRe);
             if (m && m.groups) {
-                if (m.groups.mark as DesiredMark > desiredMark)
+                if (toRank(m.groups.mark as DesiredMark) > toRank(desiredMark as DesiredMark))
                     test.skip(name, () => { });
 
                 else if (m.groups.error) {

--- a/lab11/samples/5+.bad_invariant.Error.10.27-10.33.funny
+++ b/lab11/samples/5+.bad_invariant.Error.10.27-10.33.funny
@@ -1,0 +1,14 @@
+bad_invariant(n:int)
+requires n >= 0
+returns r:int
+ensures r == n
+uses i:int
+{
+  i = 0;
+  r = 0;
+
+  while (i < n) invariant r == i {
+    i = i + 1;
+    r = r + 2;   // <- инвариант r == i больше не сохраняется
+  }
+}

--- a/lab11/samples/5+.bad_post.Error.3.9-5.2.funny
+++ b/lab11/samples/5+.bad_post.Error.3.9-5.2.funny
@@ -1,0 +1,8 @@
+bad_post(x:int)
+returns r:int
+ensures (
+  r > x
+)
+{
+  r = x-7;         // <- нарушает ensures r > x
+}

--- a/lab11/tests/testFilesInFolderAsync.ts
+++ b/lab11/tests/testFilesInFolderAsync.ts
@@ -1,6 +1,6 @@
 import { desiredMark } from '../../desiredMark.json';
 import { addIntGroup, testRe } from '../../lab08/tests/testFilesInFolder';
-import { DesiredMark } from '../../mark';
+import { DesiredMark, toRank } from '../../mark';
 import { 
     readFileSync, 
     readdirSync  } from 'fs';
@@ -9,7 +9,8 @@ import { join as pathJoin, parse as pathParse} from 'path';
 export function testFilesInFolderAsync(folder: string, parseFunc: (name: string, source: string)=>Promise<any>) {
     let files = readdirSync(folder, { withFileTypes: true, recursive: true });
     for (const file of files) {
-        const filePathString = pathJoin(file.parentPath, file.name);
+        const basePath = file.parentPath ?? folder;
+        const filePathString = pathJoin(basePath, file.name);
         const filePath = pathParse(filePathString);
 
         if (!file.isDirectory() && filePath.ext == ".funny") {
@@ -19,7 +20,7 @@ export function testFilesInFolderAsync(folder: string, parseFunc: (name: string,
 
             const processSample = async()=>parseFunc(filePath.name, sample);
             if (m && m.groups) {
-                if (m.groups.mark as DesiredMark > desiredMark)
+                if (toRank(m.groups.mark as DesiredMark) > toRank(desiredMark as DesiredMark))
                     test.skip(name, () => { });
 
                 else if (m.groups.error) {

--- a/mark/src/index.ts
+++ b/mark/src/index.ts
@@ -1,11 +1,12 @@
 import { desiredMark } from "../../desiredMark.json";
 import { test as testJs } from '@jest/globals';
 export type DesiredMark = 3|4|5|"5+";
+export const toRank = (m: DesiredMark): number => (m === "5+" ? 6 : m);
 
 
 export function test<T extends any[], R>(name: string, testMark: DesiredMark, fn:(...args:T)=>R, expected: ResultOrException<R>, ...args:T): void
 {
-    if (desiredMark >= testMark)
+    if (toRank(desiredMark as DesiredMark) >= toRank(testMark))
     {
         if(typeof expected === "function") 
         {


### PR DESCRIPTION
This PR adds proper support for the `"5+"` desired mark by introducing a rank-based comparison helper and updating mark checks across the core `mark` module and test helpers. It also includes new `5+` sample programs for lab11.

Changes:
- Add `toRank()` to compare `DesiredMark` values (treat `"5+"` as higher than `5`) and use it in mark gating logic.
- Update `desiredMark.json` to store `desiredMark` as a number (not a string), unless it is `"5+"`.
- Fix sample discovery path building by falling back to the provided `folder` when `Dirent.parentPath` is missing (sync + async).
- Add two lab11 `5+` samples (`bad_invariant`, `bad_post`).
